### PR TITLE
NEIG-24: People Page Frontend + Components

### DIFF
--- a/app/people/page.tsx
+++ b/app/people/page.tsx
@@ -2,8 +2,10 @@
 
 import React from 'react';
 import { Group, Select, TextInput, Title } from '@mantine/core';
-import { IconSearch } from '@tabler/icons-react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
 import { NeighbourhoodShell } from '@/components/NeighbourhoodShell/NeighbourhoodShell';
+import { UserList } from '@/components/UserList/UserList';
 
 export default function PeoplePage() {
   return (
@@ -15,11 +17,12 @@ export default function PeoplePage() {
           <TextInput
             radius="md"
             rightSectionPointerEvents="none"
-            rightSection={<IconSearch />}
+            rightSection={<FontAwesomeIcon icon={faMagnifyingGlass} />}
             placeholder="Search..."
           />
         </Group>
       </Group>
+      <UserList />
     </NeighbourhoodShell>
   );
 }

--- a/components/UserList/UserList.module.css
+++ b/components/UserList/UserList.module.css
@@ -1,0 +1,5 @@
+.list {
+    border: 1px solid var(--mantine-color-gray-3);
+    border-radius: var(--mantine-radius-md);
+    padding: var(--mantine-spacing-md);
+}

--- a/components/UserList/UserList.tsx
+++ b/components/UserList/UserList.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { SimpleGrid, Tabs } from '@mantine/core';
+import { UserListItem } from '../UserListItem/UserListItem';
+import classes from './UserList.module.css';
+
+//placeholder data
+const users = {
+  1: {
+    name: 'Demessie Amede',
+    username: 'damede',
+    profilePic: 'https://avatar.iran.liara.run/public/19',
+  },
+  2: {
+    name: 'Gurman Toor',
+    username: 'gtoor',
+    profilePic: 'https://avatar.iran.liara.run/public/3',
+  },
+  3: {
+    name: 'Bricz Cruz',
+    username: 'bcruz',
+    profilePic: 'https://avatar.iran.liara.run/public/15',
+  },
+  4: {
+    name: 'Safran Bin Kader',
+    username: 'sbkader',
+    profilePic: 'https://avatar.iran.liara.run/public/10',
+  },
+  5: {
+    name: 'Alborz Khakbazan',
+    username: 'alborzk',
+    profilePic: 'https://avatar.iran.liara.run/public/5',
+  },
+};
+
+const friends = {
+  1: {
+    name: 'Bricz Cruz',
+    username: 'bcruz',
+    profilePic: 'https://avatar.iran.liara.run/public/15',
+  },
+  2: {
+    name: 'Safran Bin Kader',
+    username: 'sbkader',
+    profilePic: 'https://avatar.iran.liara.run/public/10',
+  },
+};
+
+export function UserList() {
+  return (
+    <Tabs variant="outline" radius="md" defaultValue="all">
+      <Tabs.List>
+        <Tabs.Tab value="all">All</Tabs.Tab>
+        <Tabs.Tab value="friends">Friends</Tabs.Tab>
+      </Tabs.List>
+      <Tabs.Panel value="all">
+        <SimpleGrid cols={1} spacing="xs" mt="sm" className={classes.list}>
+          {Object.entries(users).map(([id, user]) => (
+            <UserListItem key={id} user={user} />
+          ))}
+        </SimpleGrid>
+      </Tabs.Panel>
+      <Tabs.Panel value="friends">
+        <SimpleGrid cols={1} spacing="xs" mt="sm" className={classes.list}>
+          {Object.entries(friends).map(([id, friend]) => (
+            <UserListItem key={id} user={friend} />
+          ))}
+        </SimpleGrid>
+      </Tabs.Panel>
+    </Tabs>
+  );
+}

--- a/components/UserListItem/UserListItem.module.css
+++ b/components/UserListItem/UserListItem.module.css
@@ -1,0 +1,17 @@
+.user {
+  display: block;
+  width: 100%;
+  padding: var(--mantine-spacing-md);
+  color: light-dark(var(--mantine-color-black), var(--mantine-color-dark-0));
+  border-radius: var(--mantine-radius-md);
+
+  @mixin hover {
+    background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-8));
+  }
+}
+
+.link {
+  text-align: center;
+  text-decoration: none;
+  color: inherit;
+}

--- a/components/UserListItem/UserListItem.tsx
+++ b/components/UserListItem/UserListItem.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { Group, Avatar, Text, Button } from '@mantine/core';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faUserPlus } from '@fortawesome/free-solid-svg-icons';
+import classes from './UserListItem.module.css';
+
+interface UserListItemProps {
+  user: User;
+}
+
+export function UserListItem({ user }: UserListItemProps) {
+  return (
+    <div className={classes.user}>
+      <Group>
+        <Avatar src={user?.profilePic} size="lg" radius="xl" />
+        <div style={{ flex: 1 }}>
+          <Text size="sm" fw={600}>
+            {user?.name}
+          </Text>
+
+          <Text c="dimmed" size="xs">
+            {user?.username}
+          </Text>
+        </div>
+
+        <Button radius="md" size="xs" leftSection={<FontAwesomeIcon icon={faUserPlus} />}>
+          Add Friend
+        </Button>
+      </Group>
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,11 @@
       "name": "mantine-next-template",
       "version": "1.0.0",
       "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.5.1",
+        "@fortawesome/free-brands-svg-icons": "^6.5.1",
+        "@fortawesome/free-regular-svg-icons": "^6.5.1",
+        "@fortawesome/free-solid-svg-icons": "^6.5.1",
+        "@fortawesome/react-fontawesome": "^0.2.0",
         "@mantine/core": "^7.5.1",
         "@mantine/dates": "^7.5.2",
         "@mantine/dropzone": "^7.5.2",
@@ -13426,6 +13431,75 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
       "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.1.tgz",
+      "integrity": "sha512-GkWzv+L6d2bI5f/Vk6ikJ9xtl7dfXtoRu3YGE6nq0p/FFqA1ebMOAWg3XgRyb0I6LYyYkiAo+3/KrwuBp8xG7A==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.5.1.tgz",
+      "integrity": "sha512-MfRCYlQPXoLlpem+egxjfkEuP9UQswTrlCOsknus/NcMoblTH2g0jPrapbcIb04KGA7E2GZxbAccGZfWoYgsrQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-brands-svg-icons": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.5.1.tgz",
+      "integrity": "sha512-093l7DAkx0aEtBq66Sf19MgoZewv1zeY9/4C7vSKPO4qMwEsW/2VYTUTpBtLwfb9T2R73tXaRDPmE4UqLCYHfg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.5.1.tgz",
+      "integrity": "sha512-m6ShXn+wvqEU69wSP84coxLbNl7sGVZb+Ca+XZq6k30SzuP3X4TfPqtycgUh9ASwlNh5OfQCd8pDIWxl+O+LlQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.5.1.tgz",
+      "integrity": "sha512-S1PPfU3mIJa59biTtXJz1oI0+KAXW6bkAb31XKhxdxtuXDiUIFsih4JR1v5BbxY7hVHsD1RKq+jRkVRaf773NQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
+      "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.3"
+      }
     },
     "node_modules/@graphql-codegen/core": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,11 @@
     "storybook:build": "storybook build"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^6.5.1",
+    "@fortawesome/free-brands-svg-icons": "^6.5.1",
+    "@fortawesome/free-regular-svg-icons": "^6.5.1",
+    "@fortawesome/free-solid-svg-icons": "^6.5.1",
+    "@fortawesome/react-fontawesome": "^0.2.0",
     "@mantine/core": "^7.5.1",
     "@mantine/dates": "^7.5.2",
     "@mantine/dropzone": "^7.5.2",


### PR DESCRIPTION

<img width="1800" alt="Screenshot 2024-02-15 at 3 32 27 AM" src="https://github.com/br-cz/neighbourhood/assets/93398491/e5824f32-5f88-4c2d-8922-d2967b446af8">

# Overview

### User List
- New UserList component basically just holds the list items for Users in the community
- Currently 2 tabs: All and Friends, but we can adjust this as needed if we want to add more options or remove it and consolidate into one list altogether
- Uses placeholder data for now until we can get data here using API queries
- Used SimpleGrid instead of Stack just in case we want to adjust how its organized later

### User List Item
- New component, pretty self-explanatory, a custom card for the User's entry in the list. You can see a User's:
  - Name
  - Username
  - Profile Pic
- Add Friend functionality and Detailed Preview Cards will be added in later tickets

### People Page
- Can rename this to Members, lmk thoughts
- Just modified it to render the UserList

### Minor Changes
- Installed fontAwesome libraries - been looking for a good icon library and this one fits the bill its pretty sick

# General Notes
- Run npm i after this is merged
- Also remember to return here to replace placeholder data later