### PR TITLE
NEIG-57: Fixed Navbar Active States

### DIFF
--- a/components/CommunityButton/CommunityButton.module.css
+++ b/components/CommunityButton/CommunityButton.module.css
@@ -4,10 +4,10 @@
   padding: var(--mantine-spacing-md);
   color: light-dark(var(--mantine-color-black), var(--mantine-color-dark-0));
   border-radius: var(--mantine-radius-md);
+}
 
-  @mixin hover {
-    background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-8));
-  }
+.community:hover, .community.active {
+  background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-8));
 }
 
 .link {

--- a/components/CommunityButton/CommunityButton.tsx
+++ b/components/CommunityButton/CommunityButton.tsx
@@ -5,12 +5,13 @@ import classes from './CommunityButton.module.css';
 
 interface CommunityButtonProps {
   user: User;
+  active: boolean;
 }
 
-export function CommunityButton({ user }: CommunityButtonProps) {
+export function CommunityButton({ user, active }: CommunityButtonProps) {
   return (
     <Link href="/communities" passHref className={classes.link}>
-      <UnstyledButton className={classes.community}>
+      <UnstyledButton className={`${classes.community} ${active ? classes.active : ''}`}>
         <Group>
           <Avatar src={user?.selectedCommunity?.image} size="md" radius="xl" />
 

--- a/components/Navbar/Navbar.module.css
+++ b/components/Navbar/Navbar.module.css
@@ -31,28 +31,12 @@
   padding: var(--mantine-spacing-sm);
   border-radius: var(--mantine-radius-md);
   font-weight: 500;
+}
 
-  @mixin hover {
+  .link:hover, .link.active{
     background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-6));
     color: light-dark(var(--mantine-color-black), var(--mantine-color-white));
-
-    .linkIcon {
-      color: light-dark(var(--mantine-color-black), var(--mantine-color-white));
-    }
   }
-
-  &[data-active] {
-    &,
-    &:hover {
-      background-color: var(--mantine-color-blue-light);
-      color: var(--mantine-color-blue-light-color);
-
-      .linkIcon {
-        color: var(--mantine-color-blue-light-color);
-      }
-    }
-  }
-}
 
 .linkIcon {
   color: light-dark(var(--mantine-color-dark-8), var(--mantine-color-gray-0));

--- a/components/Navbar/Navbar.tsx
+++ b/components/Navbar/Navbar.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { UserButton } from '@/components/UserButton/UserButton';
 import { CommunityButton } from '@/components/CommunityButton/CommunityButton';
 import classes from '@/components/Navbar/Navbar.module.css';
@@ -22,16 +23,13 @@ interface NavbarProps {
 }
 
 export function Navbar({ user }: NavbarProps) {
-  const [active, setActive] = useState('Home');
-
   const links = data.map((item) => (
     <Link
       href={item.link}
       key={item.label}
       role="button"
       tabIndex={0}
-      className={`${classes.link} ${active === item.label ? classes.active : ''}`}
-      onClick={() => setActive(item.label)}
+      className={`${classes.link} ${usePathname() === item.link ? classes.active : ''}`}
     >
       <item.icon className={classes.linkIcon} />
       <span>{item.label}</span>
@@ -43,8 +41,8 @@ export function Navbar({ user }: NavbarProps) {
       <div className={classes.navbarMain}>{links}</div>
 
       <div className={classes.footer}>
-        <UserButton user={user} />
-        <CommunityButton user={user} />
+        <UserButton user={user} active={usePathname() === '/profile' && true} />
+        <CommunityButton user={user} active={usePathname() === '/communities' && true} />
       </div>
     </nav>
   );

--- a/components/UserButton/UserButton.module.css
+++ b/components/UserButton/UserButton.module.css
@@ -4,10 +4,10 @@
   padding: var(--mantine-spacing-md);
   color: light-dark(var(--mantine-color-black), var(--mantine-color-dark-0));
   border-radius: var(--mantine-radius-md);
+}
 
-  @mixin hover {
-    background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-8));
-  }
+.user:hover, .user.active {
+  background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-8));
 }
 
 .link {

--- a/components/UserButton/UserButton.tsx
+++ b/components/UserButton/UserButton.tsx
@@ -5,12 +5,13 @@ import classes from './UserButton.module.css';
 
 interface UserButtonProps {
   user: User;
+  active: boolean;
 }
 
-export function UserButton({ user }: UserButtonProps) {
+export function UserButton({ user, active }: UserButtonProps) {
   return (
     <Link href="/profile" passHref className={classes.link}>
-      <UnstyledButton className={classes.user}>
+      <UnstyledButton className={`${classes.user} ${active ? classes.active : ''}`}>
         <Group>
           <Avatar src={user?.profilePic} size="md" radius="xl" />
 


### PR DESCRIPTION
<img width="1800" alt="Screenshot 2024-02-15 at 4 37 43 AM" src="https://github.com/br-cz/neighbourhood/assets/93398491/427b49f8-2070-4bcb-9d03-f474cc32d9dd">

# Overview
- Navbar active states weren't working because of the local "active" state being reverted when navigating page to page
- Fixed css and modified the logic to use the current router path to determine what page is active instead of using state
- Also added "active" props to the custom UserButton and CommunityButton so that they can be styled too