### PR TITLE
NEIG-52: Implemented Notification System

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { MantineProvider, ColorSchemeScript } from '@mantine/core';
+import { Notifications } from '@mantine/notifications';
 import ConfigureAmplifyClientSide from '@/components/ConfigureAmplify';
 import '@mantine/core/styles.css';
 import '@mantine/dates/styles.css';
 import '@mantine/dropzone/styles.css';
+import '@mantine/notifications/styles.css';
 import { theme } from '../theme';
 import { DataProvider } from '@/contexts/DataContext';
 
@@ -33,6 +35,7 @@ export default function RootLayout({ children }: { children: any }) {
       <body>
         <ConfigureAmplifyClientSide />
         <MantineProvider theme={theme}>
+          <Notifications />
           <DataProvider>{children}</DataProvider>
         </MantineProvider>
       </body>

--- a/components/Authorization/loginForm.client.tsx
+++ b/components/Authorization/loginForm.client.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/navigation';
 import { generateClient } from 'aws-amplify/api';
 import { getCurrentUser, signIn, signOut, type SignInInput } from 'aws-amplify/auth';
 import { Box, Button, Group, PasswordInput, Text, TextInput } from '@mantine/core';
+import { notifications } from '@mantine/notifications';
 import { useDisclosure } from '@mantine/hooks';
 import { getCommunity, getUser } from '@/src/graphql/queries';
 
@@ -50,6 +51,10 @@ const LoginForm: React.FC = () => {
         localStorage.setItem('currentCommunity', JSON.stringify(community.data.getCommunity));
       }
       router.push('/home');
+      notifications.show({
+        title: 'Welcome back! 👋 ',
+        message: 'Logged in successfully.',
+      });
     } catch (error) {
       console.log('Error signing in', error);
       setErrorMessage('Oops! Check your details and try again.');

--- a/components/Authorization/loginForm.client.tsx
+++ b/components/Authorization/loginForm.client.tsx
@@ -52,10 +52,12 @@ const LoginForm: React.FC = () => {
       }
       router.push('/home');
       notifications.show({
-        title: 'Welcome back! 👋 ',
-        message: 'Logged in successfully.',
+        radius: 'md',
+        title: 'Hey, Neighbour! 👋 ',
+        message: `Logged in successfully. Welcome back, ${user.data.getUser?.firstName}!`,
       });
     } catch (error) {
+      handlers.close();
       console.log('Error signing in', error);
       setErrorMessage('Oops! Check your details and try again.');
     }

--- a/components/Authorization/signUpForm.client.tsx
+++ b/components/Authorization/signUpForm.client.tsx
@@ -164,7 +164,7 @@ const SignUpForm: React.FC = () => {
     }
   };
 
-  const navigateToLogin = () => router.push('/login');
+  const navigateToLogin = () => router.push('/');
 
   return (
     <Box style={{ maxWidth: 300 }} mx="auto">

--- a/components/Authorization/signUpForm.client.tsx
+++ b/components/Authorization/signUpForm.client.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { signUp } from 'aws-amplify/auth';
 import { generateClient } from 'aws-amplify/api';
 import { TextInput, PasswordInput, Button, Box, Title } from '@mantine/core';
+import { notifications } from '@mantine/notifications';
 import { createUser } from '@/src/graphql/mutations';
 
 const client = generateClient({});
@@ -73,6 +74,10 @@ const SignUpForm: React.FC = () => {
 
       console.log('Sign up success:', cognitoResponse.userId);
       setIsSignUpSuccessful(true);
+      notifications.show({
+        title: 'Signed up successfully!',
+        message: 'You can now log in to continue to Neighbourhood.',
+      });
     } catch (error) {
       console.log('error signing up:', error);
       setSignUpError('An unexpected error occurred.');

--- a/components/Authorization/signUpForm.client.tsx
+++ b/components/Authorization/signUpForm.client.tsx
@@ -75,6 +75,7 @@ const SignUpForm: React.FC = () => {
       console.log('Sign up success:', cognitoResponse.userId);
       setIsSignUpSuccessful(true);
       notifications.show({
+        radius: 'md',
         title: 'Signed up successfully!',
         message: 'You can now log in to continue to Neighbourhood.',
       });

--- a/components/Authorization/useAuth.ts
+++ b/components/Authorization/useAuth.ts
@@ -16,6 +16,7 @@ export function useAuth(redirectUrl: string = '/') {
     } catch (err) {
       router.push(redirectUrl);
       notifications.show({
+        radius: 'md',
         title: 'You were logged out!',
         message: 'Please log in to continue to Neighbourhood.',
       });

--- a/components/Authorization/useAuth.ts
+++ b/components/Authorization/useAuth.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { getCurrentUser } from 'aws-amplify/auth';
+import { notifications } from '@mantine/notifications';
 
 export function useAuth(redirectUrl: string = '/') {
   const [user, setUser] = useState<any>(null);
@@ -14,6 +15,10 @@ export function useAuth(redirectUrl: string = '/') {
       setLoading(false);
     } catch (err) {
       router.push(redirectUrl);
+      notifications.show({
+        title: 'You were logged out!',
+        message: 'Please log in to continue to Neighbourhood.',
+      });
     }
   }
 

--- a/components/NeighbourhoodShell/NeighbourhoodShell.tsx
+++ b/components/NeighbourhoodShell/NeighbourhoodShell.tsx
@@ -22,6 +22,7 @@ export const NeighbourhoodShell: React.FC<NeighbourhoodShellProps> = ({ children
       localStorage.removeItem('currentUser');
       router.push('/');
       notifications.show({
+        radius: 'md',
         title: 'Logged out!',
         message: 'Log back in to continue using Neighborhood.',
       });

--- a/components/NeighbourhoodShell/NeighbourhoodShell.tsx
+++ b/components/NeighbourhoodShell/NeighbourhoodShell.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { signOut } from 'aws-amplify/auth';
 import { AppShell, Group, Burger, Button } from '@mantine/core';
+import { notifications } from '@mantine/notifications';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useDisclosure } from '@mantine/hooks';
@@ -20,6 +21,10 @@ export const NeighbourhoodShell: React.FC<NeighbourhoodShellProps> = ({ children
       await signOut({ global: true });
       localStorage.removeItem('currentUser');
       router.push('/');
+      notifications.show({
+        title: 'Logged out!',
+        message: 'Log back in to continue using Neighborhood.',
+      });
       console.log('Signed out!');
     } catch (error) {
       console.log('error signing out: ', error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@mantine/dropzone": "^7.5.2",
         "@mantine/form": "^7.5.1",
         "@mantine/hooks": "^7.5.1",
+        "@mantine/notifications": "^7.5.3",
         "@next/bundle-analyzer": "^14.0.1",
         "@parcel/watcher": "^2.4.0",
         "@tabler/icons-react": "^2.40.0",
@@ -887,30 +888,6 @@
       "dependencies": {
         "@aws-sdk/client-sts": "3.504.0",
         "@aws-sdk/credential-provider-env": "3.502.0",
-        "@aws-sdk/credential-provider-process": "3.502.0",
-        "@aws-sdk/credential-provider-sso": "3.504.0",
-        "@aws-sdk/credential-provider-web-identity": "3.504.0",
-        "@aws-sdk/types": "3.502.0",
-        "@smithy/credential-provider-imds": "^2.2.1",
-        "@smithy/property-provider": "^2.1.1",
-        "@smithy/shared-ini-file-loader": "^2.3.1",
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/backend-cli/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.504.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.504.0.tgz",
-      "integrity": "sha512-6+V5hIh+tILmUjf2ZQWQINR3atxQVgH/bFrGdSR/sHSp/tEgw3m0xWL3IRslWU1e4/GtXrfg1iYnMknXy68Ikw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.502.0",
-        "@aws-sdk/credential-provider-http": "3.503.1",
-        "@aws-sdk/credential-provider-ini": "3.504.0",
         "@aws-sdk/credential-provider-process": "3.502.0",
         "@aws-sdk/credential-provider-sso": "3.504.0",
         "@aws-sdk/credential-provider-web-identity": "3.504.0",
@@ -15743,6 +15720,29 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/@mantine/notifications": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/@mantine/notifications/-/notifications-7.5.3.tgz",
+      "integrity": "sha512-08mWoGBfc8sGDTRthBg/HYPD8dRHyugZpeUH1U7RjWQmYD4ktdkT8bdBocStTSJkCQIvtP7OPJ1MiKln1idt5w==",
+      "dependencies": {
+        "@mantine/store": "7.5.3",
+        "react-transition-group": "4.4.5"
+      },
+      "peerDependencies": {
+        "@mantine/core": "7.5.3",
+        "@mantine/hooks": "7.5.3",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/@mantine/store": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/@mantine/store/-/store-7.5.3.tgz",
+      "integrity": "sha512-jLTIaChJr9rWtzSRp2HQGHfuoFcr3ylD0JW/vsE5gpFvhoZFfkrxx5QsM1kn5wV34rZo0nQNMIJ8hvBVvfJtLQ==",
+      "peerDependencies": {
+        "react": "^18.2.0"
+      }
+    },
     "node_modules/@mdx-js/react": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-2.3.0.tgz",
@@ -20910,7 +20910,7 @@
       "version": "15.7.11",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
       "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/qs": {
       "version": "6.9.11",
@@ -20928,7 +20928,7 @@
       "version": "18.2.34",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.34.tgz",
       "integrity": "sha512-U6eW/alrRk37FU/MS2RYMjx0Va2JGIVXELTODaTIYgvWGCV4Y4TfTUzG8DdmpDNIT0Xpj/R7GfyHOJJrDttcvg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -20954,7 +20954,7 @@
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
       "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/semver": {
       "version": "7.5.6",
@@ -25469,6 +25469,15 @@
       "dev": true,
       "dependencies": {
         "utila": "~0.4"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dom-serializer": {
@@ -35552,6 +35561,21 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
       }
     },
     "node_modules/read-pkg": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@mantine/dropzone": "^7.5.2",
     "@mantine/form": "^7.5.1",
     "@mantine/hooks": "^7.5.1",
+    "@mantine/notifications": "^7.5.3",
     "@next/bundle-analyzer": "^14.0.1",
     "@parcel/watcher": "^2.4.0",
     "@tabler/icons-react": "^2.40.0",


### PR DESCRIPTION


https://github.com/br-cz/neighbourhood/assets/93398491/3ff91e33-0962-4a0c-bec9-10e93a4b1f60

# Overview

Implemented Mantine's notifications system so that we can keep notify the user of successes, fails, info, etc. For now, I've added it to:
- Log in
- Log out
- Signup
- Auth (Accessing a page when you're not signed in)

However, we should also add it to (at least)
- Creating an event/post/marketplace listing
- Saving profile/login details after editing

And maybe? probably?
- Adding/accepting friends
- RSVPing to an event (if we add this)

Quick note:
- Had some issues installing this package since they've been updating Mantine over the past week. I installed with legacy-peer-deps, should be okay but run npm i and pls let me know if you guys have any issues