### PR TITLE
NEIG-63: Updated Member List Backend to use Stored IDs

### DIFF
--- a/components/Authorization/loginForm.client.tsx
+++ b/components/Authorization/loginForm.client.tsx
@@ -39,6 +39,7 @@ const LoginForm: React.FC = () => {
         query: getUser,
         variables: { id: userId },
       });
+      localStorage.setItem('currentUserID', JSON.stringify(userId));
       localStorage.setItem('currentUser', JSON.stringify(user.data.getUser));
 
       // Initialize localStorage with corresponding community
@@ -48,6 +49,10 @@ const LoginForm: React.FC = () => {
           query: getCommunity,
           variables: { id: communityID },
         });
+        localStorage.setItem(
+          'currentCommunityID',
+          JSON.stringify(user.data.getUser.selectedCommunity)
+        );
         localStorage.setItem('currentCommunity', JSON.stringify(community.data.getCommunity));
       }
       router.push('/home');

--- a/src/api/memberQueries.ts
+++ b/src/api/memberQueries.ts
@@ -1,9 +1,55 @@
 import { useState, useEffect } from 'react';
 import { generateClient } from 'aws-amplify/api';
-import { User } from '../models';
+import { getCommunity, getUser } from '@/src/graphql/queries';
 
 const client = generateClient();
 
+export const getCurrentCommunity = async () => {
+  const communityId = JSON.parse(localStorage.getItem('currentCommunityID')!);
+  const community = await client.graphql({
+    query: getCommunity,
+    variables: { id: communityId },
+  });
+  return community.data.getCommunity;
+};
+
+export const getUserByID = async (userId: string) => {
+  const user = await client.graphql({
+    query: getUser,
+    variables: { id: userId },
+  });
+  return user.data.getUser;
+};
+
+export const getCurrentUser = async () => {
+  const userId = JSON.parse(localStorage.getItem('currentUserID')!);
+  return getUserByID(userId);
+};
+
+export const useCurrentUser = () => {
+  const [user, setUser] = useState<any>();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchCurrentUser = async () => {
+      try {
+        setLoading(true);
+        setUser(await getCurrentUser());
+      } catch (err: any) {
+        setError(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchCurrentUser();
+  }, []);
+
+  return { user, loading, error };
+};
+
+//TODO: Modify this to use getCurrentCommunity to cut one API call
 export const useFetchMembers = () => {
   const [members, setMembers] = useState<any>([]);
   const [loading, setLoading] = useState(true);
@@ -18,6 +64,8 @@ export const useFetchMembers = () => {
           id
           user {
             id
+            firstName
+            lastName
             username
             profilePic
           }
@@ -32,17 +80,17 @@ export const useFetchMembers = () => {
     const fetchMembers = async () => {
       try {
         setLoading(true);
-        const userData = localStorage.getItem('userData')!;
-        const parsedUserData: User = JSON.parse(userData);
-
-        const members = await client.graphql({
+        const userData = await getCurrentUser();
+        if (!userData) {
+          return;
+        }
+        const fetchedMembers = await client.graphql({
           query: ListUserCommunities,
-          variables: { id: parsedUserData.selectedCommunity },
+          variables: { id: userData.selectedCommunity },
         });
-
-        const jsonMembers = JSON.parse(JSON.stringify(members));
+        const jsonMembers = JSON.parse(JSON.stringify(fetchedMembers));
         const filteredMembers = jsonMembers.data.listUserCommunities.items.filter(
-          (item: any) => item.communityId === parsedUserData.selectedCommunity
+          (item: any) => item.communityId === userData.selectedCommunity
         );
         setMembers(filteredMembers);
       } catch (err: any) {


### PR DESCRIPTION
# Overview

Quick update to the backend for the member list. Now store IDs in localStorage upon login instead of whole user objects, and created a couple of new functions to help the API:
  - getCurrentCommunity()
  - getUserById(string id)
  - getCurrentUser()
  - useCurrentUser()

Some things todo still (but low priority):
- useFetchMembers() can be updated to use getCurrentCommunity() as opposed to getCurrentUser() and then using user.selectedCommunity (cuts out an API call)
- Organize methods into different files if need be, I just tossed everything in here for now but I think these helpers might be relevant across the whole app