### PR TITLE
NEIG-62: Added Modal Confirmation System

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { MantineProvider, ColorSchemeScript } from '@mantine/core';
+import { ModalsProvider } from '@mantine/modals';
 import { Notifications } from '@mantine/notifications';
 import ConfigureAmplifyClientSide from '@/components/ConfigureAmplify';
 import '@mantine/core/styles.css';
@@ -36,7 +37,13 @@ export default function RootLayout({ children }: { children: any }) {
         <ConfigureAmplifyClientSide />
         <MantineProvider theme={theme}>
           <Notifications />
-          <DataProvider>{children}</DataProvider>
+          <ModalsProvider
+            modalProps={{
+              radius: 'md',
+            }}
+          >
+            <DataProvider>{children}</DataProvider>
+          </ModalsProvider>
         </MantineProvider>
       </body>
     </html>

--- a/components/NeighbourhoodShell/NeighbourhoodShell.tsx
+++ b/components/NeighbourhoodShell/NeighbourhoodShell.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { signOut } from 'aws-amplify/auth';
-import { AppShell, Group, Burger, Button } from '@mantine/core';
+import { AppShell, Group, Burger, Button, Title, Text } from '@mantine/core';
+import { modals } from '@mantine/modals';
 import { notifications } from '@mantine/notifications';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
@@ -32,6 +33,17 @@ export const NeighbourhoodShell: React.FC<NeighbourhoodShellProps> = ({ children
     }
   }
 
+  const openSignOutModal = () => {
+    modals.openConfirmModal({
+      title: <Title order={5}>Sign out?</Title>,
+      children: <Text size="sm">Are you sure you want to sign out of Neighbourhood?</Text>,
+      confirmProps: { size: 'xs', radius: 'md' },
+      cancelProps: { size: 'xs', radius: 'md' },
+      labels: { confirm: 'Confirm', cancel: 'Back' },
+      onConfirm: () => handleSignOut(),
+    });
+  };
+
   return (
     <AppShell
       header={{ height: 70 }}
@@ -49,7 +61,7 @@ export const NeighbourhoodShell: React.FC<NeighbourhoodShellProps> = ({ children
             <Burger opened={desktopOpened} onClick={toggleDesktop} visibleFrom="sm" size="sm" />
             <Image src="./logo.svg" alt="Neighbourhood Logo" width={200} height={37} priority />
           </Group>
-          <Button onClick={handleSignOut} radius="md" variant="default" color="red">
+          <Button onClick={openSignOutModal} radius="md" variant="default" color="red">
             Sign Out
           </Button>
         </Group>

--- a/components/UserListItem/UserListItem.tsx
+++ b/components/UserListItem/UserListItem.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import React, { useState } from 'react';
-import { Group, Avatar, Text, Button } from '@mantine/core';
+import { Group, Avatar, Text, Button, Title } from '@mantine/core';
+import { modals } from '@mantine/modals';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCheck, faClock, faSmile, faUserPlus, faXmark } from '@fortawesome/free-solid-svg-icons';
 import classes from './UserListItem.module.css';
@@ -13,25 +14,47 @@ interface UserListItemProps {
 
 export function UserListItem({ user, relationshipStatus }: UserListItemProps) {
   const [status, setStatus] = useState(relationshipStatus);
-  const handleAddFriend = () => {
-    // Add friend
-    setStatus('outgoing');
-  };
+
+  const handleAddFriend = () => setStatus('outgoing');
+
   const handleAcceptRequest = () => {
-    // Accept request
     setStatus('friend');
   };
+
   const handleDeclineRequest = () => {
-    // Decline request
-    setStatus('none');
+    modals.openConfirmModal({
+      title: <Title order={5}>Decline Friend Request?</Title>,
+      children: (
+        <Text size="sm">Are you sure you want to decline {user?.name}'s friend request?</Text>
+      ),
+      confirmProps: { size: 'xs', radius: 'md', color: 'red' },
+      cancelProps: { size: 'xs', radius: 'md' },
+      labels: { confirm: 'Decline', cancel: 'Back' },
+      onConfirm: () => setStatus('none'),
+    });
   };
+
   const handleRemoveFriend = () => {
-    // Remove friend
-    setStatus('none');
+    modals.openConfirmModal({
+      title: <Title order={5}>Remove Friend?</Title>,
+      children: <Text size="sm">Are you sure you want to remove {user?.name} as a friend?</Text>,
+      confirmProps: { size: 'xs', radius: 'md', color: 'red' },
+      cancelProps: { size: 'xs', radius: 'md' },
+      labels: { confirm: 'Remove', cancel: 'Back' },
+      onConfirm: () => setStatus('none'),
+    });
   };
   const handleCancelRequest = () => {
-    // Cancel request
-    setStatus('none');
+    modals.openConfirmModal({
+      title: <Title order={5}>Cancel Friend Request?</Title>,
+      children: (
+        <Text size="sm">Are you sure you cancel your outgoing friend request to {user?.name}?</Text>
+      ),
+      confirmProps: { size: 'xs', radius: 'md', color: 'red' },
+      cancelProps: { size: 'xs', radius: 'md' },
+      labels: { confirm: 'Cancel', cancel: 'Back' },
+      onConfirm: () => setStatus('none'),
+    });
   };
 
   // Decide the button based on the relationship status

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@mantine/dropzone": "^7.5.3",
         "@mantine/form": "^7.5.3",
         "@mantine/hooks": "^7.5.3",
+        "@mantine/modals": "^7.5.3",
         "@mantine/notifications": "^7.5.3",
         "@next/bundle-analyzer": "^14.0.1",
         "@parcel/watcher": "^2.4.0",
@@ -11539,6 +11540,17 @@
       "integrity": "sha512-mFI448mAs12v8FrgSVhytqlhTVrEjIfd/PqPEfwJu5YcZIq4YZdqpzJIUbANnRrFSvmoQpDb1PssdKx7Ds35hw==",
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/@mantine/modals": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/@mantine/modals/-/modals-7.5.3.tgz",
+      "integrity": "sha512-SuPvv14nZmyBcNINqr9y2TLv9xIWXrRYeG8k7QCHM3mo2exW2IHP66Zx93AEpuKbgoDc78fcJcrTqv9C7dxUWQ==",
+      "peerDependencies": {
+        "@mantine/core": "7.5.3",
+        "@mantine/hooks": "7.5.3",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
       }
     },
     "node_modules/@mantine/notifications": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@mantine/dropzone": "^7.5.3",
     "@mantine/form": "^7.5.3",
     "@mantine/hooks": "^7.5.3",
+    "@mantine/modals": "^7.5.3",
     "@mantine/notifications": "^7.5.3",
     "@next/bundle-analyzer": "^14.0.1",
     "@parcel/watcher": "^2.4.0",

--- a/theme.ts
+++ b/theme.ts
@@ -6,4 +6,5 @@ export const theme = createTheme({
   /* Put your mantine theme override here */
   fontFamily: 'Roboto Flex, sans-serif',
   primaryColor: 'dark',
+  defaultRadius: 'md',
 });


### PR DESCRIPTION


https://github.com/br-cz/neighbourhood/assets/93398491/d7fea9a7-9b96-4102-9dcd-7b450231503a

# Overview

Added and customized Mantine's ModalProvider so that we can easily call confirmation dialogs wherever needed in our code. So far, I've added them to destructive actions in the following places:
  - Signing out
  - People page
     - Declining an incoming friend request
     - Cancelling an outgoing friend request
     - Removing a current friend

Code is super easy to add to other places that need it, make a note of it if you can think of any