### PR TITLE
NEIG-121: Fixed Navbar Height Cutoff on Safari

### DIFF
--- a/components/Navbar/Navbar.module.css
+++ b/components/Navbar/Navbar.module.css
@@ -1,5 +1,5 @@
 .navbar {
-  height: rem(100vh);
+  height: rem(100%);
   width: rem(230px);
   padding: 0;
   display: flex;


### PR DESCRIPTION

<img width="1796" alt="Screenshot 2024-02-27 at 1 59 38 AM" src="https://github.com/br-cz/neighbourhood/assets/93398491/4ca456fb-9842-4f71-90a0-2ccee83899b2">

# Overview

Quick bugfix - height for navbar was being cutoff on Safari meaning the CommunityButton wasnt being rendered. Fixed up and working now.
