### PR TITLE
NEIG-170: S3 Image Expiration Fix

### DIFF
--- a/components/CommentCard/CommentCard.tsx
+++ b/components/CommentCard/CommentCard.tsx
@@ -1,18 +1,29 @@
+import { useEffect, useState } from 'react';
 import { Text, Avatar, Group, Box } from '@mantine/core';
 import classes from './CommentCard.module.css';
 import { formatPostedAt } from '@/utils/timeUtils';
 import { CommentItem } from '@/types/types';
+import { retrieveImage } from '../utils/s3Helpers/UserProfilePictureS3Helper';
 
 interface CommentCardProps {
   comment: CommentItem;
 }
 
 export function CommentCard({ comment }: CommentCardProps) {
+  const [profilePic, setProfilePic] = useState<string>('');
+
+  useEffect(() => {
+    if (!comment?.author) return;
+    retrieveImage(comment?.author?.id).then((image) => {
+      setProfilePic(image);
+    });
+  }, [comment?.author?.profilePic]);
+
   return (
     <Box className={classes.comment} data-testid="post-card">
       <Group align="center" gap="lg">
         <Group align="center" gap="xs">
-          <Avatar src={comment?.author?.profilePic} alt="Profile Pic" radius="xl" size={24} />
+          <Avatar src={profilePic} alt="Profile Pic" radius="xl" size={24} />
           <Text fz="xs" fw={600}>
             {comment?.author?.firstName} {comment?.author?.lastName}
           </Text>

--- a/components/CommunityButton/CommunityButton.tsx
+++ b/components/CommunityButton/CommunityButton.tsx
@@ -1,8 +1,10 @@
+import { useEffect, useState } from 'react';
 import { UnstyledButton, Group, Avatar, Text, rem } from '@mantine/core';
 import { IconChevronRight } from '@tabler/icons-react';
 import Link from 'next/link';
 import classes from './CommunityButton.module.css';
 import { useData } from '@/contexts/DataContext';
+import { retrieveImage } from '../utils/s3Helpers/CommunityImageS3Helper';
 
 interface CommunityButtonProps {
   active: boolean;
@@ -10,11 +12,19 @@ interface CommunityButtonProps {
 
 export function CommunityButton({ active }: CommunityButtonProps) {
   const { community } = useData();
+  const [communityImage, setCommunityImage] = useState<string>('');
+
+  useEffect(() => {
+    if (!community) return;
+    retrieveImage(community?.id).then((image) => {
+      setCommunityImage(image);
+    });
+  }, [community?.image]);
   return (
     <Link href="/communities" passHref className={classes.link} data-testid="community">
       <UnstyledButton className={`${classes.community} ${active ? classes.active : ''}`}>
         <Group>
-          <Avatar src={community?.image} size="md" radius="xl" />
+          <Avatar src={communityImage} size="md" radius="xl" />
 
           <div style={{ flex: 1 }}>
             <Text size="sm" fw={600}>

--- a/components/CommunityListItem/CommunityListItem.tsx
+++ b/components/CommunityListItem/CommunityListItem.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useToggle } from '@mantine/hooks';
 import { Group, Avatar, Text } from '@mantine/core';
 import classes from './CommunityListItem.module.css';
 import { Community } from '@/types/types';
+import { retrieveImage } from '../utils/s3Helpers/CommunityImageS3Helper';
 
 interface CommunityListItemProps {
   community: Community;
@@ -11,6 +12,15 @@ interface CommunityListItemProps {
 
 export function CommunityListItem({ community, onSelect }: CommunityListItemProps) {
   const [selected, toggleSelected] = useToggle();
+  const [communityImage, setCommunityImage] = useState<string>('');
+
+  useEffect(() => {
+    if (!community) return;
+    retrieveImage(community?.id).then((image) => {
+      setCommunityImage(image);
+    });
+  }, [community?.image]);
+
   return (
     <div
       className={`${classes.community} ${selected ? classes.active : ''}`}
@@ -24,7 +34,7 @@ export function CommunityListItem({ community, onSelect }: CommunityListItemProp
       data-testid="communities-item"
     >
       <Group>
-        <Avatar src={community.image} size="lg" radius="xl" />
+        <Avatar src={communityImage} size="lg" radius="xl" />
         <div style={{ flex: 1 }}>
           <Text size="sm" fw={600}>
             {community.name}

--- a/components/EventCard/EventCard.tsx
+++ b/components/EventCard/EventCard.tsx
@@ -1,9 +1,12 @@
+import { useEffect, useState } from 'react';
 import { Card, Image, Text, Button, Group, Center, Avatar, Stack } from '@mantine/core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBars } from '@fortawesome/free-solid-svg-icons';
 import classes from './EventCard.module.css';
 import { Event } from '@/src/API';
 import { formatDate, formatTime } from '@/utils/timeUtils';
+import { retrieveImage as retrieveProfilePic} from '../utils/s3Helpers/EventImageS3Helper';
+import { retrieveImage as retrieveEventImage } from '../utils/s3Helpers/EventImageS3Helper';
 
 interface EventCardProps {
   event: Event;
@@ -11,11 +14,28 @@ interface EventCardProps {
 }
 
 export function EventCard({ event, onView }: EventCardProps) {
+  const [profilePic, setProfilePic] = useState<string>('');
+  const [eventImage, setEventImage] = useState<string>('');
+
+  useEffect(() => {
+    if (!event?.organizer) return;
+    retrieveProfilePic(event?.organizer?.id).then((image) => {
+      setProfilePic(image);
+    });
+  }, [event?.organizer?.profilePic]);
+
+  useEffect(() => {
+    if (!event) return;
+    retrieveEventImage(event.id).then((image) => {
+      setEventImage(image);
+    });
+  }, [event?.images]);
+
   return (
     <Card withBorder radius="md" className={classes.card} data-testid="event-card">
       <a>
         <Image
-          src={event?.images?.[0] ?? './img/placeholder-img.jpg'}
+          src={eventImage ?? './img/placeholder-img.jpg'}
           height={180}
           className={classes.image}
         />
@@ -27,7 +47,7 @@ export function EventCard({ event, onView }: EventCardProps) {
 
       <Group>
         <Center>
-          <Avatar src={event?.organizer?.profilePic} size={23} radius="xl" mr="xs" />
+          <Avatar src={profilePic} size={23} radius="xl" mr="xs" />
           <Text fz="sm" c="dimmed">
             {event?.organizer?.firstName} {event?.organizer?.lastName}
           </Text>

--- a/components/Marketplace/MarketplaceCard.tsx
+++ b/components/Marketplace/MarketplaceCard.tsx
@@ -1,8 +1,11 @@
+import React, { useEffect, useState } from 'react';
 import { Card, Image, Text, Button, Group, Center, Avatar } from '@mantine/core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBars } from '@fortawesome/free-solid-svg-icons';
 import classes from './MarketplaceCard.module.css';
 import { ItemForSale } from '@/src/API';
+import { retrieveImage as retrieveProfilePicture } from '../utils/s3Helpers/UserProfilePictureS3Helper';
+import { retrieveImage as retrieveItemImage } from '../utils/s3Helpers/ItemForSaleImageS3Helper';
 
 interface MarketplaceCardProps {
   item: ItemForSale;
@@ -10,11 +13,28 @@ interface MarketplaceCardProps {
 }
 
 export function MarketplaceCard({ item, onView }: MarketplaceCardProps) {
+  const [profilePic, setProfilePic] = useState<string>('');
+  const [itemImage, setItemImage] = useState<string>('');
+
+  useEffect(() => {
+    if (!item?.seller) return;
+    retrieveProfilePicture(item?.seller?.id).then((image) => {
+      setProfilePic(image);
+    });
+  }, [item?.seller?.profilePic]);
+
+  useEffect(() => {
+    if (!item) return;
+    retrieveItemImage(item.id).then((image) => {
+      setItemImage(image);
+    });
+  }, [item?.images]);
+
   return (
     <Card withBorder radius="md" className={classes.card} data-testid="marketplace-card">
       <a>
         <Image
-          src={item?.images?.[0] ?? './img/placeholder-img.jpg'}
+          src={itemImage ?? './img/placeholder-img.jpg'}
           height={180}
           className={classes.image}
         />
@@ -30,7 +50,7 @@ export function MarketplaceCard({ item, onView }: MarketplaceCardProps) {
 
       <Group>
         <Center>
-          <Avatar src={item?.seller?.profilePic} size={23} radius="xl" mr={7} />
+          <Avatar src={profilePic} size={23} radius="xl" mr={7} />
           <Text fz="sm" c="dimmed" truncate="end">
             {item?.seller?.firstName} {item?.seller?.lastName}
           </Text>

--- a/components/Marketplace/ViewListingModal.tsx
+++ b/components/Marketplace/ViewListingModal.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Modal, Text, Group, Avatar, Image, Stack, Title } from '@mantine/core';
 import classes from './ViewListingModal.module.css';
 import { ItemForSale } from '@/src/API';
+import { retrieveImage as retrieveProfilePicture } from '../utils/s3Helpers/UserProfilePictureS3Helper';
+import { retrieveImage as retrieveItemImage } from '../utils/s3Helpers/ItemForSaleImageS3Helper';
 
 interface ViewListingModalProps {
   opened: boolean;
@@ -10,6 +12,23 @@ interface ViewListingModalProps {
 }
 
 export function ViewListingModal({ opened, onClose, item }: ViewListingModalProps) {
+  const [profilePic, setProfilePic] = useState<string>('');
+  const [itemImage, setItemImage] = useState<string>('');
+
+  useEffect(() => {
+    if (!item?.seller) return;
+    retrieveProfilePicture(item?.seller?.id).then((image) => {
+      setProfilePic(image);
+    });
+  }, [item?.seller?.profilePic]);
+
+  useEffect(() => {
+    if (!item) return;
+    retrieveItemImage(item.id).then((image) => {
+      setItemImage(image);
+    });
+  }, [item?.images]);
+
   return (
     <Modal
       opened={opened}
@@ -29,7 +48,7 @@ export function ViewListingModal({ opened, onClose, item }: ViewListingModalProp
       <Stack gap="sm">
         <Group justify="center" mb={15}>
           <Image
-            src={item?.images?.[0] ?? './img/placeholder-img.jpg'}
+            src={itemImage ?? './img/placeholder-img.jpg'}
             alt={item?.title}
             className={classes.image}
           />
@@ -44,7 +63,7 @@ export function ViewListingModal({ opened, onClose, item }: ViewListingModalProp
 
         <Title order={6}>Seller</Title>
         <Group gap="xs" align="center">
-          <Avatar src={item?.seller.profilePic} alt={item.seller.firstName} radius="xl" />
+          <Avatar src={profilePic} alt={item.seller.firstName} radius="xl" />
           <Text size="sm" c="dimmed">
             {item.seller.firstName} {item.seller.lastName}
           </Text>

--- a/components/PostCard/PostCard.tsx
+++ b/components/PostCard/PostCard.tsx
@@ -18,7 +18,7 @@ interface PostCardProps {
   isLiked: boolean;
 }
 
-export function PostCard({ post }: PostCardProps) {
+export function PostCard({ post, isLiked }: PostCardProps) {
   const [profilePic, setProfilePic] = useState<string>('');
   const { likePost, unlikePost } = usePostLikes(post.id);
   const [liked, setLiked] = useState(false);
@@ -32,7 +32,7 @@ export function PostCard({ post }: PostCardProps) {
       setProfilePic(image);
     });
   }, [post?.author?.profilePic]);
-  
+
   useEffect(() => {
     setLiked(isLiked);
   }, [isLiked]);

--- a/components/PostCard/PostCard.tsx
+++ b/components/PostCard/PostCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Text, Avatar, Group, Box, Button, Collapse, TextInput, ActionIcon } from '@mantine/core';
 import { useFormik } from 'formik';
 import { notifications } from '@mantine/notifications';
@@ -11,16 +11,25 @@ import classes from './PostCard.module.css';
 import { createCommentSchema } from './createCommentSchema';
 import { useCreateComment } from '@/src/hooks/postsCustomHooks';
 import { PostCommentList } from './PostCommentList';
+import { retrieveImage } from '../utils/s3Helpers/UserProfilePictureS3Helper';
 
 interface PostCardProps {
   post: Post;
 }
 
 export function PostCard({ post }: PostCardProps) {
+  const [profilePic, setProfilePic] = useState<string>('');
   const [comments, setComments] = useState(post.comments.items);
   const [commentOpened, { toggle: toggleComment }] = useDisclosure(false);
   const [likeOpened, { toggle: toggleLike }] = useDisclosure(false);
   const { handleCreateComment } = useCreateComment();
+
+  useEffect(() => {
+    if (!post?.author) return;
+    retrieveImage(post?.author?.id).then((image) => {
+      setProfilePic(image);
+    });
+  }, [post?.author?.profilePic]);
 
   const formik = useFormik({
     initialValues: {
@@ -46,7 +55,7 @@ export function PostCard({ post }: PostCardProps) {
   return (
     <Box className={classes.post} data-testid="post-card">
       <Group align="center" gap="xs">
-        <Avatar src={post.author.profilePic} alt="Profile Pic" radius="xl" size={32} />
+        <Avatar src={profilePic} alt="Profile Pic" radius="xl" size={32} />
         <Text size="sm" fw={600}>
           {post.author.firstName} {post.author.lastName}
         </Text>

--- a/components/ProfileCard/ProfileCard.tsx
+++ b/components/ProfileCard/ProfileCard.tsx
@@ -1,13 +1,22 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Group, Avatar, Text, Box, Stack, Title, Loader } from '@mantine/core';
 import classes from './ProfileCard.module.css';
 import { formatDate, formatUTCDate } from '@/utils/timeUtils';
 import { useCurrentUser } from '@/src/hooks/usersCustomHooks';
+import { retrieveImage } from '../utils/s3Helpers/UserProfilePictureS3Helper';
 
 export function ProfileCard() {
   const { currentUser: user, loading } = useCurrentUser();
+  const [profilePic, setProfilePic] = useState<string>('');
+
+  useEffect(() => {
+    if (!user) return;
+    retrieveImage(user?.id).then((image) => {
+      setProfilePic(image);
+    });
+  }, [user?.profilePic]);
 
   return (
     <>
@@ -17,7 +26,7 @@ export function ProfileCard() {
         ) : (
           <Box w={1000} className={classes.card} data-testid="profile-card">
             <Group gap={50}>
-              <Avatar src={user?.profilePic} size={150} radius="xl" />
+              <Avatar src={profilePic} size={150} radius="xl" />
               <Stack gap="xs">
                 <Stack gap={0}>
                   <Title order={3}>

--- a/components/UserButton/UserButton.tsx
+++ b/components/UserButton/UserButton.tsx
@@ -1,9 +1,11 @@
+import { useEffect, useState } from 'react';
 import { UnstyledButton, Group, Avatar, Text, rem } from '@mantine/core';
 import { IconChevronRight } from '@tabler/icons-react';
 import Link from 'next/link';
 import classes from './UserButton.module.css';
 import { useCurrentUser } from '@/src/hooks/usersCustomHooks';
 import { getInitials } from '../utils/utilFunctions';
+import { retrieveImage } from '../utils/s3Helpers/UserProfilePictureS3Helper';
 
 interface UserButtonProps {
   active: boolean;
@@ -11,12 +13,20 @@ interface UserButtonProps {
 
 export function UserButton({ active }: UserButtonProps) {
   const { currentUser } = useCurrentUser();
+  const [profilePic, setProfilePic] = useState<string>('');
+
+  useEffect(() => {
+    if (!currentUser) return;
+    retrieveImage(currentUser?.id).then((image) => {
+      setProfilePic(image);
+    });
+  }, [currentUser?.profilePic]);
 
   return (
     <Link href="/profile" passHref className={classes.link} data-testid="profile">
       <UnstyledButton className={`${classes.user} ${active ? classes.active : ''}`}>
         <Group>
-          <Avatar src={currentUser?.profilePic} size="md" radius="xl">
+          <Avatar src={profilePic} size="md" radius="xl">
             {getInitials(currentUser?.firstName, currentUser?.lastName)}
           </Avatar>
           <div style={{ flex: 1 }}>

--- a/components/UserListItem/UserListItem.tsx
+++ b/components/UserListItem/UserListItem.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Group, Avatar, Text, Button, Title, Popover } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { modals } from '@mantine/modals';
@@ -18,6 +18,7 @@ import {
 import * as APITypes from '@/src/API';
 import { User } from '@/types/types';
 import { UserListItemPreview } from './UserListItemPreview';
+import { retrieveImage } from '../utils/s3Helpers/UserProfilePictureS3Helper';
 
 interface UserListItemProps {
   user: User;
@@ -29,11 +30,19 @@ export function UserListItem({ user, relationshipStatus, onUpdate }: UserListIte
   const [status, setStatus] = useState(relationshipStatus);
   const [active, setActive] = useState(false);
   const [popoverOpened, setPopoverOpened] = useState(false);
+  const [profilePic, setProfilePic] = useState<string>('');
   const { handleCreateFriendRequest, error } = useCreateFriendRequest();
   const { handleCreateFriend, error: createFriendError } = useCreateFriend();
   const { handleDeleteFriend } = useDeleteFriend();
   const { handleDeleteIncomingFriendRequest } = useDeleteIncomingFriendRequest();
   const { handleDeleteOutgoingFriendRequest } = useDeleteOutgoingFriendRequest();
+
+  useEffect(() => {
+    if (!user) return;
+    retrieveImage(user?.id).then((image) => {
+      setProfilePic(image);
+    });
+  }, [user?.profilePic]);
 
   const handleButtonClicked = () => {
     if (!popoverOpened) {
@@ -281,7 +290,7 @@ export function UserListItem({ user, relationshipStatus, onUpdate }: UserListIte
           tabIndex={0}
         >
           <Group>
-            <Avatar src={user?.profilePic} size="lg" radius="xl" />
+            <Avatar src={profilePic} size="lg" radius="xl" />
             <div style={{ flex: 1 }}>
               <Text size="sm" fw={600}>
                 {user?.firstName} {user?.lastName}

--- a/components/UserListItem/UserListItemPreview.tsx
+++ b/components/UserListItem/UserListItemPreview.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Group, Avatar, Text, Box, Stack, Title } from '@mantine/core';
 import { formatDate } from '@/utils/timeUtils';
 import { User } from '@/types/types';
+import { retrieveImage } from '../utils/s3Helpers/UserProfilePictureS3Helper';
 
 interface UserListItemPreviewProps {
   user: User;
@@ -11,11 +12,20 @@ interface UserListItemPreviewProps {
 }
 
 export function UserListItemPreview({ user, relationshipStatus }: UserListItemPreviewProps) {
+  const [profilePic, setProfilePic] = useState<string>('');
+
+  useEffect(() => {
+    if (!user) return;
+    retrieveImage(user?.id).then((image) => {
+      setProfilePic(image);
+    });
+  }, [user?.profilePic]);
+
   return (
     <Box w={500} data-testid="profile-card">
       <Stack gap="xs">
         <Group>
-          <Avatar src={user?.profilePic} size={48} radius="xl" />
+          <Avatar src={profilePic} size={48} radius="xl" />
           <Stack gap={0}>
             <Title order={6}>
               {user?.firstName} {user?.lastName}

--- a/components/ViewEventModal/ViewEventModal.tsx
+++ b/components/ViewEventModal/ViewEventModal.tsx
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Modal, Text, Group, Avatar, Image, Stack, Title } from '@mantine/core';
 import classes from './ViewEventModal.module.css';
 import { Event } from '@/src/API';
 import { formatDate, formatTime } from '@/utils/timeUtils';
+import { retrieveImage as retrieveProfilePicture } from '../utils/s3Helpers/UserProfilePictureS3Helper';
+import { retrieveImage as retrieveEventImage } from '../utils/s3Helpers/EventImageS3Helper';
 
 interface ViewEventModalProps {
   opened: boolean;
@@ -11,6 +13,23 @@ interface ViewEventModalProps {
 }
 
 export function ViewEventModal({ opened, onClose, event }: ViewEventModalProps) {
+  const [profilePic, setProfilePic] = useState<string>('');
+  const [eventImage, setEventImage] = useState<string>('');
+
+  useEffect(() => {
+    if (!event?.organizer) return;
+    retrieveProfilePicture(event?.organizer?.id).then((image) => {
+      setProfilePic(image);
+    });
+  }, [event?.organizer?.profilePic]);
+
+  useEffect(() => {
+    if (!event) return;
+    retrieveEventImage(event.id).then((image) => {
+      setEventImage(image);
+    });
+  }, [event?.images]);
+
   return (
     <Modal
       opened={opened}
@@ -30,7 +49,7 @@ export function ViewEventModal({ opened, onClose, event }: ViewEventModalProps) 
       <Stack gap="sm">
         <Group justify="center" mb={15}>
           <Image
-            src={event?.images?.[0] ?? './img/placeholder-img.jpg'}
+            src={eventImage ?? './img/placeholder-img.jpg'}
             alt={event?.name}
             className={classes.image}
           />
@@ -45,7 +64,7 @@ export function ViewEventModal({ opened, onClose, event }: ViewEventModalProps) 
 
         <Title order={6}>Organizer</Title>
         <Group gap="xs" align="center">
-          <Avatar src={event.organizer.profilePic} alt={event.organizer.firstName} radius="xl" />
+          <Avatar src={profilePic} alt={event.organizer.firstName} radius="xl" />
           <Text size="sm" c="dimmed">
             {event.organizer.firstName} {event.organizer.lastName}
           </Text>

--- a/components/utils/s3Helpers/EventImageS3Helper.tsx
+++ b/components/utils/s3Helpers/EventImageS3Helper.tsx
@@ -10,6 +10,20 @@ function generateKey(fileName: string, eventId: string) {
     return `EventImages/${eventId}-${timestamp}-${fileName}`;
 }
 
+export async function retrieveImage(eventId: string) {
+  const event = await getEventAPI(eventId);
+  if (event) {
+    if (event.images && event.images[0]) {
+      if (event.images[0]?.includes(eventId)) {
+        return retrieveImageURLFromS3(event.images[0]);
+      }
+      return event.images[0];
+    }
+    throw new Error('There is no image available for event');
+  }
+  throw new Error('Event does not exist when retrieving image');
+}
+
 export async function storeImage(file: File, eventId: string) {
   if (!file || !eventId) {
     throw new Error('Invalid file or eventId');
@@ -25,9 +39,7 @@ export async function storeImage(file: File, eventId: string) {
         data: file,
       }).result;
 
-      const imageUrl = await retrieveImageURLFromS3(uploadResult.key);
-
-      await updateEventImageAPI(event.id, imageUrl, event._version);
+      await updateEventImageAPI(event.id, uploadResult.key, event._version);
       return uploadResult.key;
     }
     throw new Error('eventId given to store event image is invalid');

--- a/components/utils/s3Helpers/ItemForSaleImageS3Helper.tsx
+++ b/components/utils/s3Helpers/ItemForSaleImageS3Helper.tsx
@@ -10,6 +10,20 @@ function generateKey(fileName: string, itemId: string) {
     return `ItemForSaleImages/${itemId}-${timestamp}-${fileName}`;
 }
 
+export async function retrieveImage(itemId: string) {
+  const listing = await getListingAPI(itemId);
+  if (listing) {
+    if (listing.images && listing.images[0]) {
+      if (listing.images[0]?.includes(itemId)) {
+        return retrieveImageURLFromS3(listing.images[0]);
+      }
+      return listing.images[0];
+    }
+    throw new Error('There is no image available for listing');
+  }
+  throw new Error('Listing does not exist when retrieving image');
+}
+
 export async function storeImage(file: File, itemId: string) {
   if (!file || !itemId) {
     throw new Error('Invalid file or itemId');
@@ -25,11 +39,9 @@ export async function storeImage(file: File, itemId: string) {
         data: file,
       }).result;
 
-      const imageUrl = await retrieveImageURLFromS3(uploadResult.key);
+      await updateItemForSaleImageAPI(itemForSale.id, uploadResult.key, itemForSale._version);
 
-      await updateItemForSaleImageAPI(itemForSale.id, imageUrl, itemForSale._version);
-
-      return imageUrl; // Return the image URL for consistency
+      return uploadResult.key;
     }
     throw new Error('itemId given to store item image is invalid');
   } catch (error) {

--- a/components/utils/utilFunctions.tsx
+++ b/components/utils/utilFunctions.tsx
@@ -9,11 +9,13 @@ export const isValidUrl = (urlString: string) => {
 };
 
 export async function retrieveImageURLFromS3(imageKey: string) {
+    console.log('imageKey', imageKey);
     try {
         const result = await getUrl({
         key: imageKey,
         options: {
           validateObjectExistence: true,
+          expiresIn: 3600,
         },
       });
       return result.url.toString();

--- a/jest.setup.cjs
+++ b/jest.setup.cjs
@@ -92,6 +92,28 @@ jest.mock('@/src/api/services/user', () => ({
   updateUserEmailAPI: jest.fn(),
   createUserAPI: jest.fn(),
   createUserCommunityAPI: jest.fn(),
+  updateUserProfilePicAPI: jest.fn(),
+  getUserAPI: jest.fn(),
+}));
+
+jest.mock('@/components/utils/s3Helpers/UserProfilePictureS3Helper', () => ({
+  retrieveImage: jest.fn().mockResolvedValue(''),
+}));
+
+jest.mock('@/components/utils/s3Helpers/CommunityImageS3Helper', () => ({
+  retrieveImage: jest.fn().mockResolvedValue(''),
+}));
+
+jest.mock('@/components/utils/s3Helpers/EventImageS3Helper', () => ({
+  retrieveImage: jest.fn().mockResolvedValue(''),
+}));
+
+jest.mock('@/components/utils/s3Helpers/PostImageS3Helper', () => ({
+  retrieveImage: jest.fn().mockResolvedValue(''),
+}));
+
+jest.mock('@/components/utils/s3Helpers/ItemForSaleImageS3Helper', () => ({
+  retrieveImage: jest.fn().mockResolvedValue(''),
 }));
 
 jest.mock('@/src/hooks/eventsCustomHooks', () => ({


### PR DESCRIPTION
- Fixed issue where images from S3 were not loading properly due to expired signed URLs
- To counteract this, I stopped storing the signed URLs retrieved from S3 directly into the database and instead reverted back to storing the S3 Image keys instead. This way we can dynamically retrieve the signed URLs for each image as needed in the frontend. 
- To display any image in the app, we should use the retrieveImage function from the corresponding s3Helper (user, event, items, post, community) 