### PR TITLE
NEIG-72: Delete Your Authored Posts

### DIFF
--- a/__test__/NeighbourhoodShell.test.tsx
+++ b/__test__/NeighbourhoodShell.test.tsx
@@ -71,6 +71,9 @@ jest.mock('@/src/hooks/postsCustomHooks', () => ({
   useCreatePost: jest.fn(() => ({
     createPost: jest.fn(),
   })),
+  useDeletePost: jest.fn(() => ({
+    handleDeletePost: jest.fn(),
+  })),
   usePostLikes: jest.fn(() => ({
     likePost: mockLikePost,
     unlikePost: mockUnlikePost,

--- a/__test__/createPost.test.tsx
+++ b/__test__/createPost.test.tsx
@@ -83,6 +83,9 @@ jest.mock('@/src/hooks/postsCustomHooks', () => ({
   useCreatePost: jest.fn(() => ({
     createPost: jest.fn(),
   })),
+  useDeletePost: jest.fn(() => ({
+    handleDeletePost: jest.fn(),
+  })),
   useCreateComment: jest.fn(() => ({
     createComment: jest.fn(),
   })),

--- a/__test__/eventUtils.test.tsx
+++ b/__test__/eventUtils.test.tsx
@@ -11,6 +11,7 @@ const mockEvents = [
     datetime: '2024-01-02:00:00',
     location: 'Test Location',
     visibility: Visibility.PUBLIC,
+    _version: 1,
   },
   {
     id: '2',
@@ -21,6 +22,7 @@ const mockEvents = [
     datetime: '2024-01-05T12:00:00',
     location: 'Test Location',
     visibility: Visibility.PUBLIC,
+    _version: 1,
   },
   {
     id: '3',
@@ -36,6 +38,7 @@ const mockEvents = [
     datetime: '2024-01-15T20:00:00',
     location: 'Test Location',
     visibility: Visibility.PUBLIC,
+    _version: 1,
   },
 ];
 

--- a/__test__/postFeed.test.tsx
+++ b/__test__/postFeed.test.tsx
@@ -1,246 +1,249 @@
 /* eslint-disable testing-library/no-wait-for-multiple-assertions */
 import { MantineProvider } from '@mantine/core';
-  import { notifications } from '@mantine/notifications';
-  import { render, waitFor, screen, fireEvent } from '@testing-library/react';
-  import { DataProvider } from '@/contexts/DataContext';
-  import HomePage from '@/components/Home/HomePage';
+import { notifications } from '@mantine/notifications';
+import { render, waitFor, screen, fireEvent } from '@testing-library/react';
+import { DataProvider } from '@/contexts/DataContext';
+import HomePage from '@/components/Home/HomePage';
 
-  const userHooks = require('@/src/hooks/usersCustomHooks');
+const userHooks = require('@/src/hooks/usersCustomHooks');
 
-  const mockLikePost = jest.fn();
-  const mockUnlikePost = jest.fn();
-  const mockHandleCreateComment = jest.fn();
+const mockLikePost = jest.fn();
+const mockUnlikePost = jest.fn();
+const mockHandleCreateComment = jest.fn();
 
-  const mockData = {
-    posts: [
-      {
-        id: '1',
-        content: 'This is a test post!',
-        author: {
-          firstName: 'Bojangle',
-          lastName: 'Williams',
-        },
-        comments: {
-          items: [
-            {
-              id: 'comment1',
-              content: 'This is the first comment',
-              author: { id: 'author1', firstName: 'Commenter', lastName: 'One' },
-            },
-            {
-              id: 'comment2',
-              content: 'This is the second comment',
-              author: { id: 'author2', firstName: 'Commenter', lastName: 'Two' },
-            },
-          ],
-        },
-        isLiked: false,
+const mockData = {
+  posts: [
+    {
+      id: '1',
+      content: 'This is a test post!',
+      author: {
+        firstName: 'Bojangle',
+        lastName: 'Williams',
       },
-      {
-        id: '2',
-        content: 'This is a second test post post!',
-        author: {
-          firstName: 'Grunkle',
-          lastName: 'Williams',
-        },
-        comments: { items: [] },
-        isLiked: false,
+      comments: {
+        items: [
+          {
+            id: 'comment1',
+            content: 'This is the first comment',
+            author: { id: 'author1', firstName: 'Commenter', lastName: 'One' },
+          },
+          {
+            id: 'comment2',
+            content: 'This is the second comment',
+            author: { id: 'author2', firstName: 'Commenter', lastName: 'Two' },
+          },
+        ],
       },
-      {
-        id: '3',
-        content: 'This is a third test post!',
-        author: {
-          firstName: 'LeJon',
-          lastName: 'Brames',
-        },
-        comments: { items: [] },
-        isLiked: false,
+      isLiked: false,
+    },
+    {
+      id: '2',
+      content: 'This is a second test post post!',
+      author: {
+        firstName: 'Grunkle',
+        lastName: 'Williams',
       },
-    ],
-  };
+      comments: { items: [] },
+      isLiked: false,
+    },
+    {
+      id: '3',
+      content: 'This is a third test post!',
+      author: {
+        firstName: 'LeJon',
+        lastName: 'Brames',
+      },
+      comments: { items: [] },
+      isLiked: false,
+    },
+  ],
+};
 
-  jest.mock('@/src/hooks/postsCustomHooks', () => ({
-    useFetchPosts: jest.fn(() => ({
-      ...mockData,
-      refetch: jest.fn(),
+jest.mock('@/src/hooks/postsCustomHooks', () => ({
+  useFetchPosts: jest.fn(() => ({
+    ...mockData,
+    refetch: jest.fn(),
+  })),
+  useCreatePost: jest.fn(() => ({
+    createPost: jest.fn(),
+  })),
+  useDeletePost: jest.fn(() => ({
+    handleDeletePost: jest.fn(),
+  })),
+  usePostLikes: jest.fn(() => ({
+    likePost: mockLikePost,
+    unlikePost: mockUnlikePost,
+  })),
+  useUserLikes: jest.fn(() => ({
+    userLikes: {
+      get: () => false,
+    },
+  })),
+  useCreateComment: jest.fn(() => ({
+    handleCreateComment: mockHandleCreateComment.mockImplementation(async (commentData) => ({
+      ...commentData,
+      id: 'newComment',
+      createdAt: new Date().toISOString(),
     })),
-    useCreatePost: jest.fn(() => ({
-      createPost: jest.fn(),
-    })),
-    usePostLikes: jest.fn(() => ({
-      likePost: mockLikePost,
-      unlikePost: mockUnlikePost,
-    })),
-    useUserLikes: jest.fn(() => ({
-      userLikes: {
-        get: () => false,
-      },
-    })),
-    useCreateComment: jest.fn(() => ({
-      handleCreateComment: mockHandleCreateComment.mockImplementation(async (commentData) => ({
-        ...commentData,
-        id: 'newComment',
-        createdAt: new Date().toISOString(),
-      })),
-    })),
-  }));
+  })),
+}));
 
-  afterEach(() => {
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+const renderComponent = () =>
+  render(
+    <MantineProvider>
+      <DataProvider>
+        <HomePage />
+      </DataProvider>
+    </MantineProvider>
+  );
+
+describe('Feed Page', () => {
+  userHooks.getCurrentUser.mockResolvedValue({
+    id: '10',
+    email: 'user@email.com',
+    _version: 1,
+  });
+
+  beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  const renderComponent = () =>
-    render(
-      <MantineProvider>
-        <DataProvider>
-          <HomePage />
-        </DataProvider>
-      </MantineProvider>
+  //1.1
+  test('Renders the initial Feed page correctly', async () => {
+    renderComponent();
+    expect(screen.getByRole('heading', { name: 'Feed' })).toBeInTheDocument();
+  });
+
+  //1.2
+  test('Renders the Post feed component correctly', async () => {
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getAllByTestId('post-feed').length).toBeGreaterThan(0);
+    });
+  });
+
+  //1.3
+  test('Renders an array of Post Cards correctly', async () => {
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getAllByTestId('post-card').length).toBeGreaterThan(0);
+    });
+  });
+
+  //1.4
+  test('Renders an appropriate # of post cards to posts in the community', async () => {
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getAllByTestId('post-card').length).toBe(mockData.posts.length);
+    });
+  });
+
+  //1.5
+  test('Renders post card content correctly', async () => {
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByText('This is a test post!')).toBeInTheDocument();
+      expect(screen.getByText('Bojangle Williams')).toBeInTheDocument();
+      expect(screen.getByText('This is a second test post post!')).toBeInTheDocument();
+      expect(screen.getByText('Grunkle Williams')).toBeInTheDocument();
+      expect(screen.getByText('This is a third test post!')).toBeInTheDocument();
+      expect(screen.getByText('LeJon Brames')).toBeInTheDocument();
+    });
+  });
+
+  //1.6
+  test('Posts can be liked correctly', async () => {
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByText('This is a test post!')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getAllByTestId('like-button')[0]);
+    await waitFor(() => {
+      expect(screen.getByText('Liked')).toBeInTheDocument();
+    });
+  });
+
+  //1.7
+  test('liking and unliking a post', async () => {
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getAllByTestId('post-card')).toHaveLength(mockData.posts.length);
+    });
+    const likeButton = screen.getAllByTestId('like-button')[0];
+    fireEvent.click(likeButton);
+    await waitFor(() => {
+      expect(mockLikePost).toHaveBeenCalledTimes(1);
+    });
+    fireEvent.click(likeButton);
+    await waitFor(() => {
+      expect(mockUnlikePost).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+//1.8
+test('Comments are rendered for a post', async () => {
+  renderComponent();
+
+  await waitFor(() => {
+    const comments = screen.getAllByTestId('comment-card');
+    expect(comments.length).toBe(2);
+    expect(screen.getByText('This is the first comment')).toBeInTheDocument();
+    expect(screen.getByText('This is the second comment')).toBeInTheDocument();
+  });
+});
+
+//1.9
+test('Clicking "Comment" makes the comment input visible', async () => {
+  renderComponent();
+  const commentButton = screen.getAllByText('Comment')[0];
+  fireEvent.click(commentButton);
+  await waitFor(() => {
+    const commentInput = screen.getAllByTestId('comment-input')[0];
+    expect(commentInput).toBeInTheDocument();
+  });
+});
+
+//1.10
+test('Submitting a comment calls create comment function', async () => {
+  renderComponent();
+
+  const commentButton = screen.getAllByText('Comment')[0];
+  fireEvent.click(commentButton);
+  await waitFor(() => {
+    expect(screen.getAllByTestId('comment-input')[0]).toBeInTheDocument();
+  });
+
+  fireEvent.change(screen.getAllByTestId('comment-input')[0], {
+    target: { value: 'New test comment' },
+  });
+  fireEvent.click(screen.getAllByTestId('submit-comment')[0]);
+  await waitFor(() => {
+    expect(mockHandleCreateComment).toHaveBeenCalledWith(
+      expect.objectContaining({ content: 'New test comment' })
     );
+  });
+});
 
-  describe('Feed Page', () => {
-    userHooks.getCurrentUser.mockResolvedValue({
-      id: '10',
-      email: 'user@email.com',
-      _version: 1,
-    });
+//1.11
+test('Submitting an invalid comment results in an error popup', async () => {
+  renderComponent();
 
-    beforeEach(() => {
-      jest.clearAllMocks();
-    });
-
-    //1.1
-    test('Renders the initial Feed page correctly', async () => {
-      renderComponent();
-      expect(screen.getByRole('heading', { name: 'Feed' })).toBeInTheDocument();
-    });
-
-    //1.2
-    test('Renders the Post feed component correctly', async () => {
-      renderComponent();
-      await waitFor(() => {
-        expect(screen.getAllByTestId('post-feed').length).toBeGreaterThan(0);
-      });
-    });
-
-    //1.3
-    test('Renders an array of Post Cards correctly', async () => {
-      renderComponent();
-      await waitFor(() => {
-        expect(screen.getAllByTestId('post-card').length).toBeGreaterThan(0);
-      });
-    });
-
-    //1.4
-    test('Renders an appropriate # of post cards to posts in the community', async () => {
-      renderComponent();
-      await waitFor(() => {
-        expect(screen.getAllByTestId('post-card').length).toBe(mockData.posts.length);
-      });
-    });
-
-    //1.5
-    test('Renders post card content correctly', async () => {
-      renderComponent();
-      await waitFor(() => {
-        expect(screen.getByText('This is a test post!')).toBeInTheDocument();
-        expect(screen.getByText('Bojangle Williams')).toBeInTheDocument();
-        expect(screen.getByText('This is a second test post post!')).toBeInTheDocument();
-        expect(screen.getByText('Grunkle Williams')).toBeInTheDocument();
-        expect(screen.getByText('This is a third test post!')).toBeInTheDocument();
-        expect(screen.getByText('LeJon Brames')).toBeInTheDocument();
-      });
-    });
-
-    //1.6
-    test('Posts can be liked correctly', async () => {
-      renderComponent();
-      await waitFor(() => {
-        expect(screen.getByText('This is a test post!')).toBeInTheDocument();
-      });
-      fireEvent.click(screen.getAllByTestId('like-button')[0]);
-      await waitFor(() => {
-        expect(screen.getByText('Liked')).toBeInTheDocument();
-      });
-    });
-
-    //1.7
-    test('liking and unliking a post', async () => {
-      renderComponent();
-      await waitFor(() => {
-        expect(screen.getAllByTestId('post-card')).toHaveLength(mockData.posts.length);
-      });
-      const likeButton = screen.getAllByTestId('like-button')[0];
-      fireEvent.click(likeButton);
-      await waitFor(() => {
-        expect(mockLikePost).toHaveBeenCalledTimes(1);
-      });
-      fireEvent.click(likeButton);
-      await waitFor(() => {
-        expect(mockUnlikePost).toHaveBeenCalledTimes(1);
-      });
-    });
+  const commentButton = screen.getAllByText('Comment')[0];
+  fireEvent.click(commentButton);
+  await waitFor(() => {
+    expect(screen.getAllByTestId('comment-input')[0]).toBeInTheDocument();
   });
 
-  //1.8
-  test('Comments are rendered for a post', async () => {
-    renderComponent();
-
-    await waitFor(() => {
-      const comments = screen.getAllByTestId('comment-card');
-      expect(comments.length).toBe(2);
-      expect(screen.getByText('This is the first comment')).toBeInTheDocument();
-      expect(screen.getByText('This is the second comment')).toBeInTheDocument();
-    });
+  fireEvent.change(screen.getAllByTestId('comment-input')[0], {
+    target: { value: '' },
   });
-
-  //1.9
-  test('Clicking "Comment" makes the comment input visible', async () => {
-    renderComponent();
-    const commentButton = screen.getAllByText('Comment')[0];
-    fireEvent.click(commentButton);
-    await waitFor(() => {
-      const commentInput = screen.getAllByTestId('comment-input')[0];
-      expect(commentInput).toBeInTheDocument();
-    });
+  fireEvent.click(screen.getAllByTestId('submit-comment')[0]);
+  await waitFor(() => {
+    expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ title: 'Oops!' }));
   });
-
-  //1.10
-  test('Submitting a comment calls create comment function', async () => {
-    renderComponent();
-
-    const commentButton = screen.getAllByText('Comment')[0];
-    fireEvent.click(commentButton);
-    await waitFor(() => {
-      expect(screen.getAllByTestId('comment-input')[0]).toBeInTheDocument();
-    });
-
-    fireEvent.change(screen.getAllByTestId('comment-input')[0], {
-      target: { value: 'New test comment' },
-    });
-    fireEvent.click(screen.getAllByTestId('submit-comment')[0]);
-    await waitFor(() => {
-      expect(mockHandleCreateComment).toHaveBeenCalledWith(
-        expect.objectContaining({ content: 'New test comment' })
-      );
-    });
-  });
-
-  //1.11
-  test('Submitting an invalid comment results in an error popup', async () => {
-    renderComponent();
-
-    const commentButton = screen.getAllByText('Comment')[0];
-    fireEvent.click(commentButton);
-    await waitFor(() => {
-      expect(screen.getAllByTestId('comment-input')[0]).toBeInTheDocument();
-    });
-
-    fireEvent.change(screen.getAllByTestId('comment-input')[0], {
-      target: { value: '' },
-    });
-    fireEvent.click(screen.getAllByTestId('submit-comment')[0]);
-    await waitFor(() => {
-      expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ title: 'Oops!' }));
-    });
-  });
+});

--- a/__test__/postUtils.test.tsx
+++ b/__test__/postUtils.test.tsx
@@ -10,6 +10,7 @@ const mockPosts = [
     createdAt: '2023-12-20T12:00:00',
     visibility: Visibility.PUBLIC,
     comments: { items: [] },
+    _version: 1,
   },
   {
     id: '1',
@@ -19,6 +20,7 @@ const mockPosts = [
     createdAt: '2023-12-26T10:00:00',
     visibility: Visibility.PUBLIC,
     comments: { items: [] },
+    _version: 1,
   },
   {
     id: '3',
@@ -28,6 +30,7 @@ const mockPosts = [
     createdAt: '2023-12-16T20:00:00',
     visibility: Visibility.PUBLIC,
     comments: { items: [] },
+    _version: 1,
   },
 ];
 

--- a/components/Home/HomePage.tsx
+++ b/components/Home/HomePage.tsx
@@ -49,7 +49,12 @@ export default function HomePage() {
           </Button>
         </Group>
       </Group>
-      <PostFeed refresh={refresh} searchQuery={searchQuery} sortQuery={sortQuery} />
+      <PostFeed
+        refresh={refresh}
+        searchQuery={searchQuery}
+        sortQuery={sortQuery}
+        onUpdate={toggleRefresh}
+      />
       <CreatePostDrawer
         opened={drawerOpened}
         onClose={drawerHandlers.close}

--- a/components/Home/PostCard/PostCard.tsx
+++ b/components/Home/PostCard/PostCard.tsx
@@ -1,25 +1,40 @@
 import { useState, useEffect } from 'react';
-import { Text, Avatar, Group, Box, Button, Collapse, TextInput, ActionIcon } from '@mantine/core';
+import {
+  Text,
+  Avatar,
+  Group,
+  Box,
+  Button,
+  Collapse,
+  TextInput,
+  ActionIcon,
+  Title,
+} from '@mantine/core';
 import { useFormik } from 'formik';
+import { modals } from '@mantine/modals';
 import { notifications } from '@mantine/notifications';
 import { useDisclosure } from '@mantine/hooks';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faArrowRight, faComment, faHeart } from '@fortawesome/free-solid-svg-icons';
+import { faArrowRight, faComment, faHeart, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { Post } from '@/types/types';
 import { formatPostedAt } from '@/utils/timeUtils';
 import classes from './PostCard.module.css';
 import { createCommentSchema } from './createCommentSchema';
-import { useCreateComment, usePostLikes } from '@/src/hooks/postsCustomHooks';
+import { useCreateComment, useDeletePost, usePostLikes } from '@/src/hooks/postsCustomHooks';
 import { PostCommentList } from './PostCommentList';
 import { retrieveImage } from '../../utils/s3Helpers/UserProfilePictureS3Helper';
+import { useCurrentUser } from '@/src/hooks/usersCustomHooks';
 
 interface PostCardProps {
   post: Post;
   isLiked: boolean;
+  onUpdate?: () => void;
 }
 
-export function PostCard({ post, isLiked }: PostCardProps) {
+export function PostCard({ post, isLiked, onUpdate }: PostCardProps) {
+  const { currentUser } = useCurrentUser();
   const [profilePic, setProfilePic] = useState<string>('');
+  const { handleDeletePost } = useDeletePost();
   const { likePost, unlikePost } = usePostLikes(post.id);
   const [liked, setLiked] = useState(false);
   const [likeCount, setLikeCount] = useState(post.likeCount || 0);
@@ -54,6 +69,30 @@ export function PostCard({ post, isLiked }: PostCardProps) {
     },
   });
 
+  const handleDelete = () => {
+    handleDeletePost(post);
+    onUpdate?.();
+  };
+
+  const openDeleteModal = () => {
+    modals.openConfirmModal({
+      title: (
+        <Title order={5} component="p">
+          Delete post?
+        </Title>
+      ),
+      children: (
+        <Text size="sm">
+          Are you sure you want to delete your post? This action cannot be undone.
+        </Text>
+      ),
+      confirmProps: { size: 'xs', radius: 'md', color: 'red.6' },
+      cancelProps: { size: 'xs', radius: 'md' },
+      labels: { confirm: 'Delete', cancel: 'Back' },
+      onConfirm: () => handleDelete(),
+    });
+  };
+
   const handleLike = async () => {
     if (liked) {
       await unlikePost();
@@ -76,6 +115,18 @@ export function PostCard({ post, isLiked }: PostCardProps) {
         <Text size="xs" c="dimmed">
           {formatPostedAt(post.createdAt)}
         </Text>
+        {currentUser?.id === post.author.id && (
+          <ActionIcon
+            color="red.6"
+            radius="xl"
+            variant="subtle"
+            size="sm"
+            onClick={openDeleteModal}
+            data-testid="remove-image"
+          >
+            <FontAwesomeIcon icon={faTrash} size="xs" />
+          </ActionIcon>
+        )}
       </Group>
       <Text mt="xs" size="sm">
         {post.content}

--- a/components/Home/PostFeed/PostFeed.tsx
+++ b/components/Home/PostFeed/PostFeed.tsx
@@ -8,10 +8,12 @@ export function PostFeed({
   refresh,
   searchQuery,
   sortQuery,
+  onUpdate,
 }: {
   refresh: boolean;
   searchQuery: string;
   sortQuery: string | null;
+  onUpdate?: () => void;
 }) {
   const { posts, loading } = useFetchPosts(refresh);
   const { userLikes } = useUserLikes();
@@ -43,7 +45,12 @@ export function PostFeed({
           data-testid="post-feed"
         >
           {filteredAndSortedPosts.map((post: Post) => (
-            <PostCard key={post.id} post={post} isLiked={userLikes.get(post.id)} />
+            <PostCard
+              key={post.id}
+              post={post}
+              isLiked={userLikes.get(post.id)}
+              onUpdate={onUpdate}
+            />
           ))}
         </SimpleGrid>
       )}

--- a/src/api/services/post.tsx
+++ b/src/api/services/post.tsx
@@ -6,8 +6,9 @@ import {
   updatePost,
   createUserLikedPosts,
   deleteUserLikedPosts,
+  deletePost,
 } from '@/src/graphql/mutations';
-import { CommentDataInput, PostDataInput } from '@/types/types';
+import { CommentDataInput, PostDataInput, Post } from '@/types/types';
 import { HttpError } from '@/src/models/error/HttpError';
 import { UserLikedPosts } from '@/src/API';
 import { getCurrentUserID } from '@/src/hooks/usersCustomHooks';
@@ -58,6 +59,8 @@ export const getCommunityPostsAPI = async (communityId: string) => {
             createdAt
             userPostsId
             visibility
+            _version
+            _deleted
             likedBy {
               items {
                 userId
@@ -97,6 +100,24 @@ export const getCommunityPostsAPI = async (communityId: string) => {
       `Error retrieving community posts: ${error.message}`,
       error.statusCode || 500
     );
+  }
+};
+
+export const deletePostAPI = async (post: Post) => {
+  try {
+    const response = await client.graphql({
+      query: deletePost,
+      variables: {
+        input: {
+          id: post.id,
+          _version: post._version,
+        },
+      },
+    });
+    console.log('Post deleted successfully:', response.data.deletePost);
+    return response.data.deletePost;
+  } catch (error: any) {
+    throw new HttpError(`Error deleting post: ${error.message}`, error.statusCode || 500);
   }
 };
 

--- a/types/types.ts
+++ b/types/types.ts
@@ -68,6 +68,8 @@ export interface Post {
   comments: Comments;
   visibility: Visibility;
   createdAt: string;
+  _version: number;
+  _deleted?: boolean;
 }
 
 export interface Event {
@@ -82,6 +84,8 @@ export interface Event {
   attendees?: User[];
   likedBy?: User[];
   visibility: Visibility;
+  _version: number;
+  _deleted?: boolean;
 }
 
 export interface ItemForSale {
@@ -95,6 +99,8 @@ export interface ItemForSale {
   community: Community;
   likedBy: User[];
   visibility: Visibility;
+  _version: number;
+  _deleted?: boolean;
 }
 
 export interface FriendRequest {


### PR DESCRIPTION
Users who authored a post have the option to delete it. Presents a confirmation modal and refreshes the feed upon deleting

TECHNICALLY a little scuffed because it doesnt also delete all of the comments related to said post - but I think it should be fine at least for now? Those comments dont have any impact by being left "undeleted" so for demoing/usability its probably good. Can fix if needed though

https://github.com/br-cz/neighbourhood/assets/93398491/f11e619b-c209-4c8b-b2b4-194b743acbfc

